### PR TITLE
Added more necessary steps for get-tools.sh and fix path for train-lm.sh

### DIFF
--- a/script/get-tools.sh
+++ b/script/get-tools.sh
@@ -53,7 +53,7 @@ fi
 
 # Install Egret
 if [[ ! -e $TD/egret ]]; then
-
+    
     git clone https://github.com/neubig/egret.git $TD/egret 
     cd $TD/egret
     make -j $CORES 
@@ -70,6 +70,7 @@ if [[ ! -e $TD/Ckylark ]]; then
     make -j $CORES 
     
     # Get chinese models (temporary)
+    mkdir -p $TD/Ckylark/model
     cd $TD/Ckylark/model
     wget http://www.phontron.com/download/ckylark-ctb.tar.gz
     tar -xzf ckylark-ctb.tar.gz
@@ -85,6 +86,7 @@ if [[ ! -e $TD/bin/kytea ]]; then
     git clone https://github.com/neubig/kytea.git $TD/kytea
     
     cd $TD/kytea
+    gunzip data/model.bin.gz # Needs to unzip the models file before autoreconf
     autoreconf -i
     ./configure --prefix=$TD
     make -j $CORES 

--- a/script/get-tools.sh
+++ b/script/get-tools.sh
@@ -100,7 +100,7 @@ fi
 
 # Install util-scirpts in ~/work/
 if [[ ! -e $WD/work ]]; then
-    git clone https://github.com/neubig/util-scripts.git $WD/work
+    git clone https://github.com/neubig/util-scripts.git $TD/util-scripts
 fi
     
 

--- a/script/get-tools.sh
+++ b/script/get-tools.sh
@@ -99,7 +99,7 @@ if [[ ! -e $TD/bin/kytea ]]; then
 fi
 
 # Install util-scirpts in ~/work/
-if [[ ! -e $WD/work ]]; then
+if [[ ! -e $TD/util-scripts ]]; then
     git clone https://github.com/neubig/util-scripts.git $TD/util-scripts
 fi
     

--- a/script/get-tools.sh
+++ b/script/get-tools.sh
@@ -60,7 +60,7 @@ if [[ ! -e $TD/egret ]]; then
 
 fi
 
-# Install Egret
+# Install Ckylark
 if [[ ! -e $TD/Ckylark ]]; then
 
     git clone https://github.com/odashi/Ckylark.git $TD/Ckylark 
@@ -77,7 +77,11 @@ if [[ ! -e $TD/Ckylark ]]; then
 
     # Unzip models
     gunzip $TD/Ckylark/model/*.gz
-
+    
+    # Create symbolic link to lowercase $TD/cylark directory 
+    # (somehow travatar's preprocess.pl uses it when doing one-best parse,
+    #  when doing script/run-preproc.sh)
+    ln -s $TD/ckylark $TD/Ckylark
 fi
 
 # Install KyTea

--- a/script/get-tools.sh
+++ b/script/get-tools.sh
@@ -96,6 +96,12 @@ if [[ ! -e $TD/bin/kytea ]]; then
 
 fi
 
+# Install util-scirpts in ~/work/
+if [[ ! -e $WD/work ]]; then
+    git clone https://github.com/neubig/util-scripts.git $WD/work
+fi
+    
+
 ################### Finish #################################################
 
 echo "Finished getting tools!"

--- a/script/train-lm.sh
+++ b/script/train-lm.sh
@@ -9,14 +9,15 @@ TDIR=$WD/tools/travatar
 NDIR=$WD/tools/nile
 MDIR=$MD/tools/mosesdecoder
 SDIR=$MD/tools/srilm
+UDIR=$WD/tools/util-scripts
 CORES=`nproc`
 
 # ********* LM preprocessing *********
 if [[ ! -e lm/data ]]; then
     mkdir -p lm/data
-    cat lm/raw/*.ja | sed 's/、/，/g;  s/（）//g; s/ //g' | ~/work/util-scripts/han2zen.pl --nospace | $KDIR/src/bin/kytea -model $KDIR/data/model.bin -notags -wsconst D > lm/data/all.ja
-    cat lm/raw/*.en | $TDIR/src/bin/tokenizer | sed "s/[     ]+/ /g; s/^ +//g; s/ +$//g" | ~/work/travatar/src/bin/tree-converter -input_format word -output_format word -split '(-|\\/)' | $TDIR/script/recaser/truecase.pl --model ja-en/preproc/train/truecaser/en.truecaser > lm/data/all.en
-    cat lm/raw/*.zh | $KDIR/src/bin/kytea -model $KDIR/data/ctb-0.4.0-5.mod | sed 's/（ *） *//g' | ~/work/util-scripts/han2zen.pl --nospace 2> /dev/null > lm/data/all.zh
+    cat lm/raw/*.ja | sed 's/、/，/g;  s/（）//g; s/ //g' | $UDIR/han2zen.pl --nospace | $KDIR/src/bin/kytea -model $KDIR/data/model.bin -notags -wsconst D > lm/data/all.ja
+    cat lm/raw/*.en | $TDIR/src/bin/tokenizer | sed "s/[     ]+/ /g; s/^ +//g; s/ +$//g" | $TDIR/src/bin/tree-converter -input_format word -output_format word -split '(-|\\/)' | $TDIR/script/recaser/truecase.pl --model ja-en/preproc/train/truecaser/en.truecaser > lm/data/all.en
+    cat lm/raw/*.zh | $KDIR/src/bin/kytea -model $KDIR/data/ctb-0.4.0-5.mod | sed 's/（ *） *//g' | $UDIR/han2zen.pl --nospace 2> /dev/null > lm/data/all.zh
 fi
 
 # ********* LM training *********


### PR DESCRIPTION
- **Added mkdir on line 74 in get-tools.sh**:Without making the directory for the CKY Lark model before `cd $TD/Ckylark/model`, it breaks the script.
- **Added gunzip on line 89 in get-tools.sh**: Also, without unzipping the data model for KyTea, the script breaks.
- **Added util-scripts installation to get-tools.sh**
- **Use dynamic path for TDIR and UDIR in train-lm.sh**
